### PR TITLE
Zombies on scene bugfix (dead npcs weren't remove from scene)

### DIFF
--- a/src/hierarchy/IBestiary.hpp
+++ b/src/hierarchy/IBestiary.hpp
@@ -12,7 +12,7 @@ private:
 public:
     explicit Id(const T* id) : m_id(id) {}
     bool operator== (const Id& rhv) const { return m_id == rhv.m_id; }
-    bool operator< (const Id& rhv) const { return m_id == rhv.m_id; }
+    bool operator< (const Id& rhv) const { return m_id < rhv.m_id; }
 };
 
 
@@ -30,7 +30,11 @@ protected:
 public:
     friend bool is_same(const Compariable& lhv, const Compariable& rhv) { return lhv.id() == rhv.id(); }
     friend bool is_predecessor(const Compariable& lhv, const Compariable& rhv) { return lhv.id() < rhv.id(); }
+
+    virtual ~Compariable() = 0;
 };
+
+inline Compariable::~Compariable() = default;
 
 
 class Attacker : virtual public Compariable

--- a/src/hierarchy/Scene.cpp
+++ b/src/hierarchy/Scene.cpp
@@ -54,8 +54,6 @@ void Scene::binary_find_and_erase(
 
     if (it != vec.cend())
         vec.erase(it);
-    else
-        assert(false);
 }
 
 template <class Key>
@@ -81,7 +79,6 @@ Scene::Scene(std::size_t npc_num, const BestiaryFactory& fact, IEventDispatcher&
     ed.is_dead_subscribe(
         [this] (Attacker* a_npc, Defender* d_npc, Applier&)
         {
-            assert(d_npc);
             remove(a_npc, d_npc);
         }
     );
@@ -89,7 +86,6 @@ Scene::Scene(std::size_t npc_num, const BestiaryFactory& fact, IEventDispatcher&
     ed.on_create_subscribe(
         [this] (std::shared_ptr<Attacker> a_npc, std::shared_ptr<Defender> d_npc, Applier&)
         {
-            assert(d_npc);
             ///@todo Not thread safe
             static std::size_t cnt= 0;
             std::stringstream ss;
@@ -112,6 +108,8 @@ Scene::Scene(std::size_t npc_num, const BestiaryFactory& fact, IEventDispatcher&
 // Implying that names are unique!
 void Scene::add(const std::string& name, std::shared_ptr<Attacker> aiface, std::shared_ptr<Defender> diface)
 {
+    assert(aiface || diface);
+    assert(!(aiface && diface) || is_same(*aiface, *diface));
     if (aiface)
         binary_find_and_insert(m_attackers, aiface, name);
     if (diface)
@@ -121,6 +119,7 @@ void Scene::add(const std::string& name, std::shared_ptr<Attacker> aiface, std::
 void Scene::remove(Attacker* aiface, Defender* diface)
 {
     assert(aiface || diface);
+    assert(!(aiface && diface) || is_same(*aiface, *diface));
     /// @todo What about nullptrs?
     if (aiface)
         binary_find_and_erase(m_attackers, *aiface);


### PR DESCRIPTION
  - fixed misstype in less comparing function on Id class caused the bug
  - more asserts for Scene methods using new Comparable::is_same() function
  - class Comparable is declared as abstract using pure virtual dtor technique